### PR TITLE
Inverts condition when setting RAILS_DB in hook

### DIFF
--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -27,7 +27,7 @@ if [ -z "$RAILS_DB" ]; then
   echo 1>&2
   exit 5
 else
-  if ! [ "$(type -t set_env_var)" == "function" ]; then
+  if [ "$(type -t set_env_var)" == "function" ]; then
     set_env_var 'RAILS_DB' $RAILS_DB $OPENSHIFT_HOMEDIR/.env/user_vars
   fi
 fi


### PR DESCRIPTION
This looks like silly error but myabe I am not right.

Why test if set_env_var is function and use it when it is not?

With original condition I cannot find RAILS_DB file at $RAILS_DB $OPENSHIFT_HOMEDIR/.env/user_vars directory and running rails c when sshed into gear show that rails connects to sqlite in both development and production envs despite fact that I have MySQL running.

Removing negation in this condition causes RAILS_DB env variable to be present and correctly filled accordind to what db is running and rails c show that it connects to correct db.