### PR TITLE
Prevent leaking credentials on error

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,1 @@
+PassengerFriendlyErrorPages off


### PR DESCRIPTION
Turns off Passenger’s friendly error pages feature which dumps the whole environment to the page with every password and secret.

@mfojtik : any comments on this?